### PR TITLE
Fix IMC object allocation counts

### DIFF
--- a/spec/fixtures/singleton_class/in_class.rb
+++ b/spec/fixtures/singleton_class/in_class.rb
@@ -15,10 +15,13 @@ class Runner
 end
 
 Runner.new.run
+Runner.new.run
+Runner.new.run
+Runner.new.run
 
 alive_count = LivingDead.traced_objects.select { |tracer| tracer.retained? }.length
 
-expected = Integer(ENV["EXPECTED_OUT"] || 0)
+expected = Integer(ENV["EXPECTED_OUT"] || 1)
 actual = alive_count
 result = expected == actual ? "PASS" : "FAIL"
 puts "#{result}: expected: #{expected}, actual: #{actual}"

--- a/spec/fixtures/singleton_class/simple.rb
+++ b/spec/fixtures/singleton_class/simple.rb
@@ -12,10 +12,13 @@ def run
 end
 
 run
+run
+run
+run
 
 alive_count = LivingDead.traced_objects.select { |tracer| tracer.retained? }.length
 
-expected = Integer(ENV["EXPECTED_OUT"] || 0)
+expected = Integer(ENV["EXPECTED_OUT"] || 1)
 actual = alive_count
 result = expected == actual ? "PASS" : "FAIL"
 puts "#{result}: expected: #{expected}, actual: #{actual}"

--- a/spec/fixtures/singleton_class_instance_eval/in_class.rb
+++ b/spec/fixtures/singleton_class_instance_eval/in_class.rb
@@ -15,10 +15,13 @@ class Runner
 end
 
 Runner.new.run
+Runner.new.run
+Runner.new.run
+Runner.new.run
 
 alive_count = LivingDead.traced_objects.select { |tracer| tracer.retained? }.length
 
-expected = Integer(ENV["EXPECTED_OUT"] || 0)
+expected = Integer(ENV["EXPECTED_OUT"] || 1)
 actual = alive_count
 result = expected == actual ? "PASS" : "FAIL"
 puts "#{result}: expected: #{expected}, actual: #{actual}"

--- a/spec/fixtures/singleton_class_instance_eval/simple.rb
+++ b/spec/fixtures/singleton_class_instance_eval/simple.rb
@@ -13,10 +13,13 @@ def run
 end
 
 run
+run
+run
+run
 
 alive_count = LivingDead.traced_objects.select { |tracer| tracer.retained? }.length
 
-expected = Integer(ENV["EXPECTED_OUT"] || 0)
+expected = Integer(ENV["EXPECTED_OUT"] || 1)
 actual = alive_count
 result = expected == actual ? "PASS" : "FAIL"
 puts "#{result}: expected: #{expected}, actual: #{actual}"


### PR DESCRIPTION
In these cases, the object's class isn't actually `Object`, but the
singleton class for that instance.  The inline method cache retains a
reference to the singleton class, and the singleton class retains a
reference to the object from which it was created.

In these tests, the inline method cache hasn't been deleted, so the last
object that was referenced will be retained.  In other words, the
minimum number of live objects when executing this code will always be 1.  We can call `run` multiple times, then GC, then prove that only one
object is retained even though we made a few objects.